### PR TITLE
BarbarianWallDemolisher: Rename name of settings object

### DIFF
--- a/src/BarbarianWallDemolisher.js
+++ b/src/BarbarianWallDemolisher.js
@@ -190,4 +190,4 @@ class BarbarianWallDemolisher {
 
 }
 
-new BarbarianWallDemolisher(window.userSettings ?? {}).exec();
+new BarbarianWallDemolisher(window.settings || window.userSettings).exec();


### PR DESCRIPTION
Backwards compatible - `userSettings` name is also valid.