### PR TITLE
Change `rollup-plugin-banner` to `rollup-plugin-banner2`

### DIFF
--- a/config/rollup.config.prod.js
+++ b/config/rollup.config.prod.js
@@ -1,9 +1,8 @@
 import { readFileSync } from "node:fs";
 import { defineConfig } from "rollup";
 import terser from "@rollup/plugin-terser";
-import banner_ from "rollup-plugin-banner";
+import banner from "rollup-plugin-banner2";
 
-const banner = banner_.default;
 const bannerCommentRegExp = /^\/\*\*.*?\*\//s;
 
 const bannerComment = path => {
@@ -28,6 +27,8 @@ export default filename => defineConfig({
         ascii_only: true,
       }
     }),
-    banner(bannerComment(`./src/${filename}`)),
+    banner(() => bannerComment(`./src/${filename}`), {
+      formatter: "docBlockAndGap",
+    }),
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "^8.57.0",
         "rollup": "^3.29.1",
         "rollup-plugin-ascii": "^0.0.3",
-        "rollup-plugin-banner": "^0.2.1",
+        "rollup-plugin-banner2": "^1.3.0",
         "rollup-plugin-strip-code": "^0.2.7",
         "terser-webpack-plugin": "^5.3.9"
       }
@@ -1919,36 +1919,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/lru-cache": {
       "version": "10.0.1",
@@ -2459,13 +2434,25 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node_modules/rollup-plugin-banner": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-banner/-/rollup-plugin-banner-0.2.1.tgz",
-      "integrity": "sha512-Bs1uIPCsGpKIkNOwmBsCqn+dJ/xaojWk9PNlvd+1MEScddr1yUQlO6McAXi72wJyNWYL+9u9EI2JAZMpLRH92w==",
+    "node_modules/rollup-plugin-banner2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-banner2/-/rollup-plugin-banner2-1.3.0.tgz",
+      "integrity": "sha512-ehXBo4ziTayAwtyeNTc0Gc3IVBI6pqMtdvoX7B88WJHBXzA3BrUUvAQ7OSNOLB3ulgZyugDJypNh1PrFR3uiVQ==",
       "dev": true,
       "dependencies": {
-        "lodash.template": "^4.4.0"
+        "magic-string": "^0.25.7"
+      },
+      "engines": {
+        "node": ">=12.13"
+      }
+    },
+    "node_modules/rollup-plugin-banner2/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/rollup-plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "^8.57.0",
     "rollup": "^3.29.1",
     "rollup-plugin-ascii": "^0.0.3",
-    "rollup-plugin-banner": "^0.2.1",
+    "rollup-plugin-banner2": "^1.3.0",
     "rollup-plugin-strip-code": "^0.2.7",
     "terser-webpack-plugin": "^5.3.9"
   },


### PR DESCRIPTION
The `rollup-plugin-banner2` is more maintained that the old plugin (last update was August 5, 2019).
This plugin also resolves [vulnerability issue of command injection in lodash.template](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) by simply not using it.